### PR TITLE
bump to haproxy:alpine3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:alpine3.19
+FROM haproxy:alpine3.20
 
 USER root
 


### PR DESCRIPTION
Usikker på hvorfor dependabot ikke har fanget opp ny release. Det er i hvert fall på tide å bygge imaget på nytt